### PR TITLE
Fix array overwrite in InitNormal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
 - which cem
 - cem --help
 - cem --version
-# - cem
+- cem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set (BUILD_SHARED_LIBS ON)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-set(bmicem_sources cem/cem.c bmi/bmi_cem.c)
+set(bmicem_sources cem/cem.c cem/rocks.c cem/utils.c bmi/bmi_cem.c)
 
 add_library(bmi_cem ${bmicem_sources})
 add_library(bmi_cem-static STATIC ${bmicem_sources})

--- a/cem/cem.c
+++ b/cem/cem.c
@@ -3956,48 +3956,44 @@ float RandZeroToOne(void)
   return ((float)(AB_rand));
 }
 
-void InitNormal(void)
-/* Creates initial beach conditions */
-/* Flat beach with zone of AllBeach = 'y' separated by AllBeach = 'n' */
-/* Block of rock parallel to beach begins at INIT_ROCK LMV */
-/* LMV Assume that AllBeach = 'Y' for AllRock cells (and All Full cells)
-   */
-/* Bounding layer set to random fraction of fullness */
-{
-  int x, y, n; /* y1 */
-  int InitialBeach;
-  int InitialRock;
-  int Amp; /*Amplitude of cos curve */
-  int blocks =
-      1; /* have hard stuff just as blocks near the beach, or columns? */
-  printf("Condition Initial \n");
 
-  Amp = 10;
+// Creates initial beach conditions
+// Flat beach with zone of AllBeach = 'y' separated by AllBeach = 'n'
+// Block of rock parallel to beach begins at INIT_ROCK LMV
+// LMV Assume that AllBeach = 'Y' for AllRock cells (and All Full cells)
+// Bounding layer set to random fraction of fullness
+void InitNormal(void)
+{
+  int x, y, n;
+  int initial_beach;
+  int initial_rock;
+  const double amp = 10.; // Amplitude of cos curve */
+  // have hard stuff just as blocks near the beach, or columns?
+  const int blocks = 1;
+
+  printf("Condition Initial \n");
 
   for (y = 0; y < 2 * Y_MAX; y++)
     for (x = 0; x < X_MAX; x++) {
-      InitialBeach = INIT_BEACH;
-      InitialRock = INIT_ROCK;
+      initial_beach = INIT_BEACH;
+      initial_rock = INIT_ROCK;
 
       if (DIFFUSIVE_HUMP)
-      /* shoreline is a cosine curve, diffusive LMV */
-      {
-        InitialRock = (INIT_ROCK + (-Amp * cos((2 * PI * y) / Y_MAX)) -
-                       (INIT_BEACH - INIT_ROCK - 1));
-        InitialBeach = (INIT_BEACH + (-Amp * cos((2 * PI * y) / Y_MAX)));
+      { // shoreline is a cosine curve, diffusive LMV
+        initial_rock = (INIT_ROCK + (-Amp * cos((2 * PI * y) / Y_MAX)) -
+                        (INIT_BEACH - INIT_ROCK - 1));
+        initial_beach = (INIT_BEACH + (-Amp * cos((2 * PI * y) / Y_MAX)));
       }
 
-      if (x < InitialRock)
-      /*LMV*/ {
+      if (x < initial_rock)
+      { // LMV
         PercentFullRock[x][y] = 1.0;
         PercentFullSand[x][y] = 0.0;
         AllRock[x][y] = 'y';
         AllBeach[x][y] = 'n';
         topography[x][y] = kCliffHeightSlow;
-      }
-
-      else if (x == InitialRock)
-      /*LMV*/ {
+      } else if (x == initial_rock)
+      { // LMV
         if (INITIAL_SMOOTH_ROCK) {
           PercentFullRock[x][y] = 0.20;
           PercentFullSand[x][y] = 0.80;
@@ -4008,17 +4004,15 @@ void InitNormal(void)
         AllRock[x][y] = 'n';
         AllBeach[x][y] = 'y';
         topography[x][y] = kCliffHeightSlow;
-      }
-
-      else if ((x > InitialRock) && (x < InitialBeach))
-      /*LMV*/ {
+      } else if ((x > initial_rock) && (x < initial_beach))
+      { // LMV
         PercentFullRock[x][y] = 0.0;
         PercentFullSand[x][y] = 1.0;
         AllRock[x][y] = 'n';
         AllBeach[x][y] = 'y';
         topography[x][y] = 0;
 
-      } else if (x == InitialBeach) {
+      } else if (x == initial_beach) {
         if (INITIAL_SMOOTH) {
           PercentFullSand[x][y] = 0.5;
         } else {
@@ -4028,9 +4022,7 @@ void InitNormal(void)
         AllBeach[x][y] = 'n';
         topography[x][y] = 0;
 
-      }
-
-      else if (x > InitialBeach) {
+      } else if (x > initial_beach) {
         PercentFullSand[x][y] = 0;
         AllRock[x][y] = 'n';
         AllBeach[x][y] = 'n';
@@ -4041,24 +4033,26 @@ void InitNormal(void)
     }
 
   // LMV Assign fast and slow weathering portions
-  for (x = 0; x < X_MAX; x++) {
-    for (n = 0; n <= 2 * NUMBER_CHUNK; n++) {
-      for (y = n * CHUNK_LENGTH; y < ((n + 2) * CHUNK_LENGTH); y++) {
-        if (n % 3 == 0 && (!blocks || x > InitialRock - 3)) { /* if even */
-          TypeOfRock[x][y] = 's';
-          topography[x][y] = kCliffHeightSlow;
-        }
+  {
+    const int chunk_length = Y_MAX / (1 + NUMBER_CHUNK);
 
-        else { /*if odd */
-          TypeOfRock[x][y] = 'f';
-          topography[x][y] = kCliffHeightFast;
+    for (x = 0; x < X_MAX; x++) {
+      for (n = 0; n <= 2 * NUMBER_CHUNK; n++) {
+        for (y = n * chunk_length; y < ((n + 2) * chunk_length); y++) {
+          if (n % 2 == 0 && (!blocks || x > initial_rock - 3)) { // if even
+            TypeOfRock[x][y] = 's';
+            topography[x][y] = kCliffHeightSlow;
+          } else { // if odd
+            TypeOfRock[x][y] = 'f';
+            topography[x][y] = kCliffHeightFast;
+          }
         }
       }
     }
-    /*for (y=0;y<=Y_MAX;y++)
-       printf("x %d, y %d, Type %c\n", x, y, TypeOfRock[x][y]); */
   }
+
 }
+
 
 int initBlock(void) {
   int x, y, n, blockHeight = 4, blockWidth = 60,

--- a/cem/cem.c
+++ b/cem/cem.c
@@ -469,7 +469,6 @@ int cem_finalize(void) {
   free(wave_dir);
 
   printf("Run Complete.  Output file: %s \n", savefilename);
-  getchar();
 
   return 0;
 }

--- a/cem/cem.c
+++ b/cem/cem.c
@@ -3996,9 +3996,9 @@ void InitNormal(void)
 
       if (DIFFUSIVE_HUMP)
       { // shoreline is a cosine curve, diffusive LMV
-        initial_rock = (INIT_ROCK + (-Amp * cos((2 * PI * y) / Y_MAX)) -
+        initial_rock = (INIT_ROCK + (-amp * cos((2 * PI * y) / Y_MAX)) -
                         (INIT_BEACH - INIT_ROCK - 1));
-        initial_beach = (INIT_BEACH + (-Amp * cos((2 * PI * y) / Y_MAX)));
+        initial_beach = (INIT_BEACH + (-amp * cos((2 * PI * y) / Y_MAX)));
       }
 
       if (x < initial_rock)

--- a/cem/cem.c
+++ b/cem/cem.c
@@ -221,7 +221,7 @@ void OopsImEmpty(int x, int y);
 void OopsImFull(int x, int y);
 void ParseSWAN(int ShoreAngleLoc, float ShoreAngle);
 void PauseRun(int x, int y, int in);
-void PeriodicBoundaryCopy(void);
+void periodic_boundary_copy(void);
 float Raise(float b, float e);
 float RandZeroToOne(void);
 void ReadSandFromFile(void);
@@ -312,7 +312,7 @@ int cem_initialize(void) {
   }
 
   /* Set Periodic Boundary Conditions */
-  PeriodicBoundaryCopy();
+  periodic_boundary_copy();
 
   /* Count Initial Mass */
   MassInitial = MassCount();
@@ -358,7 +358,7 @@ int cem_update(void) {
                current_time_step);
       }
 
-      PeriodicBoundaryCopy(); /* Copy visible data to external model - creates
+      periodic_boundary_copy(); /* Copy visible data to external model - creates
                                  boundaries */
 
       ZeroVars();
@@ -4299,31 +4299,23 @@ void InitPert(void)
   }
 }
 
-void PeriodicBoundaryCopy(void)
-/* Simulates periodic boundary conditions by copying middle section to front and
-   end of arrays */
-{
-  int x, y;
 
-  for (y = Y_MAX; y < 3 * Y_MAX / 2; y++)
-    for (x = 0; x < X_MAX; x++) {
-      AllBeach[x][y - Y_MAX] = AllBeach[x][y];
-      AllRock[x][y - Y_MAX] = AllRock[x][y];
-      /*LMV*/ type_of_rock[x][y - Y_MAX] = type_of_rock[x][y];
-      /*LMV*/ PercentFullSand[x][y - Y_MAX] = PercentFullSand[x][y];
-      PercentFullRock[x][y - Y_MAX] = PercentFullRock[x][y];
-      /*LMV*/ Age[x][y - Y_MAX] = Age[x][y];
-    }
-  for (y = Y_MAX / 2; y < Y_MAX; y++)
-    for (x = 0; x < X_MAX; x++) {
-      AllBeach[x][y + Y_MAX] = AllBeach[x][y];
-      AllRock[x][y + Y_MAX] = AllRock[x][y];
-      /*LMV*/ type_of_rock[x][y + Y_MAX] = type_of_rock[x][y];
-      /*LMV*/ PercentFullSand[x][y + Y_MAX] = PercentFullSand[x][y];
-      PercentFullRock[x][y + Y_MAX] = PercentFullRock[x][y];
-      /*LMV*/ Age[x][y + Y_MAX] = Age[x][y];
-    }
+// Apply periodic boundary conditions to CEM arrays.
+void periodic_boundary_copy(void)
+{
+  const int buff_len = 2 * Y_MAX;
+  int row;
+
+  for (row=0; row < X_MAX; row++) {
+    apply_periodic_boundary(AllBeach[row], sizeof(char), buff_len);
+    apply_periodic_boundary(AllRock[row], sizeof(char),  buff_len);
+    apply_periodic_boundary(type_of_rock[row], sizeof(char), buff_len);
+    apply_periodic_boundary(PercentFullSand[row], sizeof(double), buff_len);
+    apply_periodic_boundary(PercentFullRock[row], sizeof(double),buff_len);
+    apply_periodic_boundary(Age[row], sizeof(int), buff_len);
+  }
 }
+
 
 void ZeroVars(void)
 /* Resets all arrays recalculated at each time step to 'zero' conditions */
@@ -4440,7 +4432,7 @@ void ReadSandFromFile(void)
   fclose(ReadSandFile);
   printf("file read!");
 
-  PeriodicBoundaryCopy();
+  periodic_boundary_copy();
 }
 
 void SaveSandToFile(void)
@@ -4524,7 +4516,7 @@ void SaveSandToFile(void)
   fclose(SaveSandFile);
   printf("file saved!\n");
 
-  PeriodicBoundaryCopy();
+  periodic_boundary_copy();
 }
 
 void SaveLineToFile(void)

--- a/cem/consts.h
+++ b/cem/consts.h
@@ -145,7 +145,7 @@ extern "C" {
 #define INITIAL_SMOOTH_ROCK (1)
 // Alongshore length of a chunk of fast or slow weathering rock LMV
 // (used to be Y_MAX/NumberChunk)
-#define CHUNK_LENGTH (100)
+// #define CHUNK_LENGTH (100)
 
 /* De-bugging Parameters */
 

--- a/cem/rocks.c
+++ b/cem/rocks.c
@@ -1,0 +1,38 @@
+#include "utils.h"
+#include "rocks.h"
+
+
+extern double kCliffHeightSlow;
+extern double kCliffHeightFast;
+
+
+// LMV Assign fast and slow weathering portions
+// Divide rows of rocks into fast and slow rock types.
+void set_rock_blocks(char **rock_type, double **topography, const int n_rows,
+    const int n_cols, const int n_blocks)
+{
+  const int chunk_length = (n_cols / 2) / n_blocks;
+  const int n_fast = chunk_length / 2;
+  const int n_slow = chunk_length - n_fast;
+  int col;
+
+  { // Set blocks of rock type.
+    char *stripe = (char*)malloc(sizeof(char) * (n_fast + n_slow));
+    for (col=0; col < n_fast; col++) stripe[col] = 'f';
+    for (col=0; col < n_slow; col++) stripe[col + n_fast] = 's';
+    stripe_cem_matrix((void**)rock_type, n_rows, n_cols, sizeof(char),
+        stripe, n_fast + n_slow);
+    free(stripe);
+  }
+
+  { // Set blocks of cliff height.
+    double *stripe = (double*)malloc(sizeof(double) * (n_fast + n_slow));
+    for (col=0; col < n_fast; col++) stripe[col] = kCliffHeightFast;
+    for (col=0; col < n_slow; col++) stripe[col + n_fast] = kCliffHeightSlow;
+    stripe_cem_matrix((void**)topography, n_rows, n_cols, sizeof(double),
+        stripe, n_fast + n_slow);
+    free(stripe);
+  }
+
+  return;
+}

--- a/cem/rocks.h
+++ b/cem/rocks.h
@@ -1,0 +1,17 @@
+#ifndef ROCKS_INCLUDED
+#define ROCKS_INCLUDED
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+void set_rock_blocks(char **rock_type, double **topography, const int n_rows,
+    const int n_cols, const int n_blocks);
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/cem/utils.c
+++ b/cem/utils.c
@@ -3,7 +3,7 @@
 
 #include "utils.h"
 
-
+// Allocate memory for a 2D matrix as a continuous block.
 void **malloc2d(size_t n_rows, size_t n_cols, size_t itemsize)
 {
   size_t i;
@@ -15,7 +15,7 @@ void **malloc2d(size_t n_rows, size_t n_cols, size_t itemsize)
   return matrix;
 }
 
-
+// Free memory allocated with malloc2d.
 void free2d(void **mem)
 {
   free(mem[0]);
@@ -23,17 +23,20 @@ void free2d(void **mem)
 }
 
 
+// Apply periodic boundary conditions to a CEM array.
+//
+// In CEM preiodic boundary conditions are implemented by using an array
+// that is twice as large as the domain on which equations are being
+// solved. The first/last quarters of the larger buffer are simply
+// copies of the second/first halves of the solution domain.
 void apply_periodic_boundary(void *array, const int itemsize, const int nitems)
 {
-  const int width_items = nitems / 2;
-  const int left_items = (nitems - width_items) / 2;
-  const int right_items = nitems - (width_items + left_items);
   const int nbytes = nitems * itemsize;
-  const int width_nbytes = width_items * itemsize;
-  const int left_nbytes = left_items * itemsize;
-  const int right_nbytes = right_items * itemsize;
+  const int middle_nbytes = (nitems / 2) * itemsize;
+  const int left_nbytes = (nitems - nitems / 2) / 2 * itemsize;
+  const int right_nbytes = nbytes - (middle_nbytes + left_nbytes);
 
-  memcpy(array, array + width_nbytes, left_nbytes);
+  memcpy(array, array + middle_nbytes, left_nbytes);
   memcpy(array + nbytes - right_nbytes, array + left_nbytes, right_nbytes);
 }
 

--- a/cem/utils.c
+++ b/cem/utils.c
@@ -1,0 +1,70 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+
+void **malloc2d(size_t n_rows, size_t n_cols, size_t itemsize)
+{
+  size_t i;
+  void **matrix = malloc(sizeof(void*) * n_rows);
+  matrix[0] = malloc(itemsize * n_rows * n_cols);
+  for (i = 1; i < n_rows ; i++)
+    matrix[i] = matrix[i - 1] + n_cols * itemsize;
+
+  return matrix;
+}
+
+
+void free2d(void **mem)
+{
+  free(mem[0]);
+  free(mem);
+}
+
+
+void apply_periodic_boundary(void *array, const int itemsize, const int nitems)
+{
+  const int width_items = nitems / 2;
+  const int left_items = (nitems - width_items) / 2;
+  const int right_items = nitems - (width_items + left_items);
+  const int nbytes = nitems * itemsize;
+  const int width_nbytes = width_items * itemsize;
+  const int left_nbytes = left_items * itemsize;
+  const int right_nbytes = right_items * itemsize;
+
+  memcpy(array, array + width_nbytes, left_nbytes);
+  memcpy(array + nbytes - right_nbytes, array + left_nbytes, right_nbytes);
+}
+
+
+// Repeat a block within an array until the array is filled.
+void repeat_mem(void *dst, const int len, void *block, int block_len) {
+  const int n_blocks = len / block_len;
+  const int last_block_len = len - n_blocks * block_len;
+  int offset;
+
+  for (offset=0; offset < len; offset += block_len) {
+    memcpy(dst + offset, block, block_len);
+  }
+  memcpy(dst + len - last_block_len, block, last_block_len);
+}
+
+
+// Run vertical stripes down a CEM matrix, making certain to obey the
+// periodic boundary conditions.
+void stripe_cem_matrix(void **matrix, int n_rows, int n_cols, int itemsize,
+    void *stripe, int nitems)
+{
+  const int offset_to_left = (n_cols / 4) * itemsize;
+  const int width = (n_cols / 2) * itemsize;
+  void *row = malloc(itemsize * n_cols);
+  int i;
+
+  repeat_mem(row + offset_to_left, width, stripe, nitems * itemsize);
+  apply_periodic_boundary(row, itemsize, n_cols);
+  for (i = 0; i < n_rows; i++)
+    memcpy(matrix[i], row, itemsize * n_cols);
+
+  free(row);
+}

--- a/cem/utils.h
+++ b/cem/utils.h
@@ -1,0 +1,24 @@
+#ifndef UTILS_INCLUDED
+#define UTILS_INCLUDED
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdlib.h>
+
+
+void **malloc2d(size_t n_rows, size_t n_cols, size_t itemsize);
+void free2d(void **mem);
+void apply_periodic_boundary(void *array, const int itemsize,
+    const int nitems);
+void repeat_mem(void *dst, const int len, void *block, int block_len);
+void stripe_cem_matrix(void **matrix, int n_rows, int n_cols, int itemsize,
+    void *stripe, int nitems);
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -36,6 +36,16 @@ if (GLIB2_FOUND)
   add_executable(test-grid ${test_grid_srcs})
   target_link_libraries(test-grid
     bmi_cem ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES})
+
+  set(test_rocks_srcs test_rocks.c)
+  add_executable(test-rocks ${test_rocks_srcs})
+  target_link_libraries(test-rocks
+    bmi_cem ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES})
+
+  set(test_utils_srcs test_utils.c)
+  add_executable(test-utils ${test_utils_srcs})
+  target_link_libraries(test-utils
+    bmi_cem ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES})
 else (GLIB2_FOUND)
   message(STATUS "No glib... SKIPPING tests.")
 endif (GLIB2_FOUND)

--- a/testing/test_irf.c
+++ b/testing/test_irf.c
@@ -30,10 +30,28 @@ static void test_bmi_update(void) {
 }
 
 
+static void test_bmi_finalize(void) {
+  BMI_Model *model = (BMI_Model *)malloc(sizeof(BMI_Model));
+  int status;
+
+  register_bmi_cem(model);
+
+  status = model->initialize(NULL, &(model->self));
+  g_assert_cmpint(status, ==, BMI_SUCCESS);
+
+  status = model->update(&(model->self));
+  g_assert_cmpint(status, ==, BMI_SUCCESS);
+
+  status = model->finalize(&(model->self));
+  g_assert_cmpint(status, ==, BMI_SUCCESS);
+}
+
+
 int main(int argc, char* argv[]) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/bmi/initialize", &test_bmi_initialize);
   g_test_add_func("/bmi/update", &test_bmi_update);
+  g_test_add_func("/bmi/finalize", &test_bmi_finalize);
 
   return g_test_run();
 }

--- a/testing/test_rocks.c
+++ b/testing/test_rocks.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+
+#include "cem/rocks.h"
+
+
+static void test_set_rock_blocks(void) {
+  const int shape[2] = {10, 20};
+  double **z = (double**)malloc(sizeof(double*) * shape[0]);
+  char **rock_type = (char**)malloc(sizeof(char*) * shape[0]);
+  int i;
+  char expected[20] = {
+    'f', 'f', 's', 's', 's',
+    'f', 'f', 's', 's', 's', 'f', 'f', 's', 's', 's',
+    'f', 'f', 's', 's', 's'
+  };
+
+  z[0] = (double*)malloc(sizeof(double) * shape[0] * shape[1]);
+  rock_type[0] = (char*)malloc(sizeof(char) * shape[0] * shape[1]);
+  for (i=1; i < shape[0]; i++) {
+    z[i] = z[i-1] + shape[1];
+    rock_type[i] = rock_type[i-1] + shape[1];
+  }
+
+  set_rock_blocks(rock_type, z, shape[0], shape[1], 2);
+
+  for (i=0; i < shape[0]; i++)
+    g_assert_cmpmem(rock_type[i], shape[1], expected, shape[1]);
+
+  free(rock_type[0]);
+  free(rock_type);
+  free(z[0]);
+  free(z);
+}
+
+
+int main(int argc, char* argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/cem/rocks/set_blocks", &test_set_rock_blocks);
+
+  return g_test_run();
+}

--- a/testing/test_utils.c
+++ b/testing/test_utils.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+
+#include "cem/utils.h"
+
+
+static void test_set_periodic_multiple_of_4(void) {
+  const int len = 12;
+  int array[12] =    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  int expected[12] = {6, 7, 8, 3, 4, 5, 6, 7, 8, 3,  4,  5};
+
+  apply_periodic_boundary(array, sizeof(int), len);
+
+  g_assert_cmpmem(array, len, expected, len);
+}
+
+
+static void test_set_periodic_even_width(void) {
+  const int len = 10;
+  int array[10] =    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int expected[10] = {5, 6, 2, 3, 4, 5, 6, 2, 3, 4};
+
+  apply_periodic_boundary(array, sizeof(int), len);
+
+  g_assert_cmpmem(array, len, expected, len);
+}
+
+
+static void test_set_periodic_odd_width(void) {
+  const int len = 11;
+  int array[11] =    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  int expected[11] = {5, 6, 7, 3, 4, 5, 6, 7, 3, 4,  5};
+
+  apply_periodic_boundary(array, sizeof(int), len);
+
+  g_assert_cmpmem(array, len, expected, len);
+}
+
+
+int main(int argc, char* argv[]) {
+  g_test_init(&argc, &argv, NULL);
+  g_test_add_func("/cem/utils/set_periodic_4", &test_set_periodic_multiple_of_4);
+  g_test_add_func("/cem/utils/set_periodic_even", &test_set_periodic_even_width);
+  g_test_add_func("/cem/utils/set_periodic_odd", &test_set_periodic_odd_width);
+
+  return g_test_run();
+}


### PR DESCRIPTION
This pull request tries to fix issue #6. The code in question is immediately after the comment,

``` c
// LMV Assign fast and slow weathering portions
```

This isn't ready to be merged quite yet as I'm not 100% sure what this section of code is intended to do.
