### PR TITLE
Remove unused BMI functions

### DIFF
--- a/bmi_cem.c
+++ b/bmi_cem.c
@@ -401,24 +401,6 @@ get_var_ndim(Bmi *self, const char *name, int *ndim)
 
 
 static int
-get_var_stride(Bmi *self, const char *name, int *stride)
-{
-    int id;
-
-    return_on_error(get_var_grid(self, name, &id));
-
-    if (id == 1) {
-        stride[0] = 1;
-    }
-    else if (id == 2) {
-        stride[0] = deltas_get_ny((CemModel*)self->data);
-        stride[1] = 1;
-    }
-
-    return BMI_SUCCESS;
-}
-
-static int
 get_var_location(Bmi *self, const char *name, char *const location)
 {
     const VarInfo *var = find_variable(name);

--- a/bmi_cem.c
+++ b/bmi_cem.c
@@ -387,20 +387,6 @@ get_var_nbytes(Bmi *self, const char *name, int *nbytes)
 
 
 static int
-get_var_ndim(Bmi *self, const char *name, int *ndim)
-{
-    int id, rank;
-
-    return_on_error(get_var_grid(self, name, &id));
-    return_on_error(get_grid_rank(self, id, &rank));
-
-    *ndim = rank;
-
-    return BMI_SUCCESS;
-}
-
-
-static int
 get_var_location(Bmi *self, const char *name, char *const location)
 {
     const VarInfo *var = find_variable(name);

--- a/bmi_waves.c
+++ b/bmi_waves.c
@@ -274,14 +274,6 @@ finalize(Bmi * self)
 
 
 static int
-get_grid_rank(Bmi *self, int id, int *rank)
-{
-    *rank = -1;
-    return BMI_FAILURE;
-}
-
-
-static int
 get_grid_size(Bmi *self, int id, int *size)
 {
     return BMI_FAILURE;
@@ -439,8 +431,8 @@ register_bmi_waves(Bmi *model)
     model->set_value = set_value;
     model->set_value_at_indices = NULL;
 
-    model->get_grid_rank = get_grid_rank;
     model->get_grid_size = get_grid_size;
+    model->get_grid_rank = NULL;
     model->get_grid_type = NULL;
     model->get_grid_shape = NULL;
     model->get_grid_spacing = NULL;

--- a/bmi_waves.c
+++ b/bmi_waves.c
@@ -274,13 +274,6 @@ finalize(Bmi * self)
 
 
 static int
-get_grid_size(Bmi *self, int id, int *size)
-{
-    return BMI_FAILURE;
-}
-
-
-static int
 get_var_grid(Bmi *self, const char *name, int *grid)
 {
     *grid = -1;
@@ -431,8 +424,8 @@ register_bmi_waves(Bmi *model)
     model->set_value = set_value;
     model->set_value_at_indices = NULL;
 
-    model->get_grid_size = get_grid_size;
     model->get_grid_rank = NULL;
+    model->get_grid_size = NULL;
     model->get_grid_type = NULL;
     model->get_grid_shape = NULL;
     model->get_grid_spacing = NULL;

--- a/bmi_waves.c
+++ b/bmi_waves.c
@@ -274,14 +274,6 @@ finalize(Bmi * self)
 
 
 static int
-get_grid_type(Bmi *self, int id, char *type)
-{
-    type[0] = '\0';
-    return BMI_FAILURE;
-}
-
-
-static int
 get_grid_rank(Bmi *self, int id, int *rank)
 {
     *rank = -1;
@@ -449,7 +441,7 @@ register_bmi_waves(Bmi *model)
 
     model->get_grid_rank = get_grid_rank;
     model->get_grid_size = get_grid_size;
-    model->get_grid_type = get_grid_type;
+    model->get_grid_type = NULL;
     model->get_grid_shape = NULL;
     model->get_grid_spacing = NULL;
     model->get_grid_origin = NULL;


### PR DESCRIPTION
I've removed some unused BMI functions. In the case of *bmi_waves* the unused functions are the `get_grid_` functions, which are unused because waves doesn't have a grid. In the case of *bmi_cem*, there were some old BMI functions that have been dropped from the standard.