### PR TITLE
Add shoreline visualization scripts for CEM outputs (plots + animation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
-# ignore _build folder
+# macOS
+.DS_Store
 
-/_build/
+# build & binaries
+_build/
+*.o
+*.a
+*.dylib
+cem
+
+# run outputs & images
+runs/
+**/runs/
+ShorePos_*.dat
+CEM_*.out
+*.gif
+*.png
+*.log
+
+# python
+__pycache__/
+*.pyc
+.venv/

--- a/cem/conditions.c
+++ b/cem/conditions.c
@@ -1,6 +1,8 @@
+#include <stdio.h>   // for printf
+#include <math.h>    // for sin, cos
 #include <stdlib.h>
 #include <string.h>
-
+#include "rocks.h"
 #include "conditions.h"
 #include "consts.h"
 #include "utils.h"

--- a/cem/consts.h
+++ b/cem/consts.h
@@ -99,7 +99,7 @@ extern "C" {
 // time step to begin saving files
 #define START_SAVING_AT (0)
 // space between saved files
-#define SAVE_SPACING (365)
+#define SAVE_SPACING (30)
 
 // char savefilename[2048] = "CEM";
 // char readfilename[2048] = "CEM_3285.out";

--- a/notes/cem_test1_20251024_YSong.md
+++ b/notes/cem_test1_20251024_YSong.md
@@ -1,0 +1,79 @@
+# CEM terminal session — 2025-10-24
+
+- host: waveletswave-3
+- shell: zsh
+- cwd: /Users/benthosyy/Desktop/1024CEM/cem/_build/runs/more
+
+## Commands
+
+```bash
+ 1001  24.10.2025 17:17  git clone https://github.com/waveletswave/cem.git
+ 1002  24.10.2025 17:18  code cem
+ 1003  24.10.2025 17:25  mkdir _build
+ 1004  24.10.2025 17:26  cd _build
+ 1005  24.10.2025 17:26  cmake ..
+ 1006  24.10.2025 17:26  make -j
+ 1007  24.10.2025 17:27  cd ~/Desktop/1024CEM
+ 1008  24.10.2025 17:27  ls -la
+ 1009  24.10.2025 17:28  cd ~/Desktop/1024CEM/cem
+ 1010  24.10.2025 17:28  ls -la | grep -E 'CMakeLists.txt|main.c'
+ 1011  24.10.2025 17:29  cd ~/Desktop/1024CEM/cem
+ 1012  24.10.2025 17:29  cmake -S . -B _build\n
+ 1013  24.10.2025 17:31  cd ~/Desktop/1024CEM/cem
+ 1014  24.10.2025 17:31  cmake --build _build -j\n
+ 1015  24.10.2025 17:39  cd ~/Desktop/1024CEM/cem
+ 1016  24.10.2025 17:39  rm -rf _build\n
+ 1017  24.10.2025 17:39  cmake -S . -B _build
+ 1018  24.10.2025 17:40  cmake --build _build -j
+ 1019  24.10.2025 17:41  cd ~/Desktop/1024CEM/cem
+ 1020  24.10.2025 17:41  cmake --build _build -- -j1
+ 1021  24.10.2025 17:43  cd ~/Desktop/1024CEM/cem/_build
+ 1022  24.10.2025 17:43  mkdir -p CMakeFiles/bmi_cem.dir/cem CMakeFiles/bmi_cem.dir/bmi \\n         CMakeFiles/bmi_cem-static.dir/cem CMakeFiles/bmi_cem-static.dir/bmi
+ 1023  24.10.2025 17:43  cmake --build . -j
+ 1024  24.10.2025 17:47  cd ~/Desktop/1024CEM/cem/_build
+ 1025  24.10.2025 17:47  mkdir -p runs/minimal
+ 1026  24.10.2025 17:47  cd runs/minimal
+ 1027  24.10.2025 17:47  ../../cem
+ 1028  24.10.2025 17:49  ls -lh
+ 1029  24.10.2025 17:50  head -n 5 ShorePos_1.dat
+ 1030  24.10.2025 17:50  head -n 5 CEM_365.out
+ 1031  24.10.2025 17:51  cd ~/Desktop/1024CEM/cem/_build/runs/minimal\n\npython3 - <<'PY'\nimport glob, io, re, numpy as np, matplotlib.pyplot as plt\ndef load_shoreline(path):\n    # Read as text, strip any '%' and compress whitespace, then load as float array\n    txt = open(path, 'r', encoding='utf-8', errors='ignore').read()\n    txt = txt.replace('%','').strip()\n    buf = io.StringIO(re.sub(r'\s+', ' ', txt))\n    arr = np.loadtxt(buf)         # 1D array of shoreline positions y(i)\n    return arr\n\nfiles = sorted(glob.glob('ShorePos_*.dat'))\nif not files:\n    raise SystemExit("No ShorePos_*.dat files found.")\n\nplt.figure()\nfor f in files:\n    y = load_shoreline(f)\n    x = np.arange(len(y))         # alongshore cell index; replace with meters if you know ds\n    plt.plot(x, y, label=f)\n\nplt.xlabel("Alongshore cell index")\nplt.ylabel("Shoreline position y")\nplt.title("CEM Shoreline Snapshots")\nplt.legend()\nplt.tight_layout()\nplt.savefig("shoreline_snapshots.png", dpi=220)\nprint("Saved shoreline_snapshots.png")\nPY\n
+ 1032  24.10.2025 17:56  cd ~/Desktop/1024CEM/cem
+ 1033  24.10.2025 17:56  mkdir -p viz
+ 1034  24.10.2025 17:56  cat > viz/requirements.txt <<'TXT'\n\ncat > viz/requirements.txt <<'TXT'\nnumpy\nmatplotlib\npillow   # for GIF export\nTXT\n\n# (optional) install into your environment\npython3 -m pip install -r viz/requirements.txt
+ 1035  24.10.2025 17:58  cd ~/Desktop/1024CEM/cem\nrm -f viz/requirements.txt\ncat <<'TXT' > viz/requirements.txt\nnumpy\nmatplotlib\npillow   # for GIF export\nTXT\n
+ 1036  24.10.2025 17:58  python3 -m pip install -r viz/requirements.txt
+ 1037  24.10.2025 17:59  cat <<'PY' > viz/plot_shoreline.py\n#!/usr/bin/env python3\nimport argparse, glob, io, re\nimport numpy as np\nimport matplotlib.pyplot as plt\nfrom pathlib import Path\n\ndef load_shoreline(path, cols):\n    txt = Path(path).read_text(encoding="utf-8", errors="ignore")\n    txt = txt.replace("%","").strip()\n    txt = re.sub(r"\s+", " ", txt)\n    arr = np.loadtxt(io.StringIO(txt))\n    if arr.ndim == 1:\n        y = arr\n    else:\n        y = arr[:, cols[1]] if arr.shape[1] > 1 else arr[:,0]\n    return y\n\ndef main():\n    p = argparse.ArgumentParser(description="Plot CEM shoreline snapshots.")\n    p.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")\n    p.add_argument("--cols", type=int, nargs=2, default=[0,1], help="Zero-based columns for x,y (used if file has multiple columns)")\n    p.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m). If not set, x is cell index.")\n    p.add_argument("--labels", default=None, help="Comma-separated legend labels (same order as sorted files)")\n    p.add_argument("--out", default="shoreline_snapshots.png", help="Output PNG filename")\n    args = p.parse_args()\n\n    files = sorted(glob.glob(args.input))\n    if not files:\n        raise SystemExit(f"No files match: {args.input}")\n\n    labels = args.labels.split(",") if args.labels else None\n    if labels and len(labels) != len(files):\n        raise SystemExit("Number of labels must match number of files.")\n\n    xs = None\n    plt.figure()\n    for i, f in enumerate(files):\n        y = load_shoreline(f, args.cols)\n        if xs is None:\n            n = len(y)\n            xs = np.arange(n) if args.ds is None else np.arange(n) * args.ds\n        lab = labels[i] if labels else Path(f).stem\n        plt.plot(xs, y, label=lab)\n\n    plt.xlabel("Alongshore distance (m)" if args.ds is not None else "Alongshore cell index")\n    plt.ylabel("Shoreline position y")\n    plt.title("CEM Shoreline Snapshots")\n    plt.legend()\n    plt.tight_layout()\n    plt.savefig(args.out, dpi=220)\n    print(f"Saved {args.out}")\n\nif __name__ == "__main__":\n    main()\nPY\nchmod +x viz/plot_shoreline.py\n
+ 1038  24.10.2025 17:59  cat <<'PY' > viz/animate_shoreline.py\n#!/usr/bin/env python3\nimport argparse, glob, io, re\nimport numpy as np\nimport matplotlib.pyplot as plt\nfrom matplotlib.animation import FuncAnimation, PillowWriter\nfrom pathlib import Path\n\ndef load_shoreline(path):\n    txt = Path(path).read_text(encoding="utf-8", errors="ignore").replace("%","").strip()\n    txt = re.sub(r"\s+", " ", txt)\n    arr = np.loadtxt(io.StringIO(txt))\n    return arr if arr.ndim == 1 else arr[:,1] if arr.shape[1] > 1 else arr[:,0]\n\ndef main():\n    p = argparse.ArgumentParser(description="Animate CEM shoreline snapshots.")\n    p.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")\n    p.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m). If not set, x is cell index.")\n    p.add_argument("--gif", default="shoreline.gif", help="Output GIF filename")\n    p.add_argument("--interval", type=int, default=300, help="Frame interval (ms)")\n    args = p.parse_args()\n\n    files = sorted(glob.glob(args.input))\n    if not files:\n        raise SystemExit(f"No files match: {args.input}")\n\n    ys = [load_shoreline(f) for f in files]\n    n = len(ys[0])\n    x = np.arange(n) if args.ds is None else np.arange(n) * args.ds\n\n    ymin = min(map(np.min, ys))\n    ymax = max(map(np.max, ys))\n\n    fig, ax = plt.subplots()\n    (line,) = ax.plot(x, ys[0])\n    ax.set_xlim(x.min(), x.max())\n    ax.set_ylim(ymin, ymax)\n    ax.set_xlabel("Alongshore distance (m)" if args.ds is not None else "Alongshore cell index")\n    ax.set_ylabel("Shoreline position y")\n    title = ax.set_title(Path(files[0]).stem)\n\n    def update(i):\n        line.set_ydata(ys[i])\n        title.set_text(Path(files[i]).stem)\n        return (line, title)\n\n    anim = FuncAnimation(fig, update, frames=len(ys), interval=args.interval, blit=True)\n    anim.save(args.gif, writer=PillowWriter(fps=1000//args.interval))\n    print(f"Saved {args.gif}")\n\nif __name__ == "__main__":\n    main()\nPY\nchmod +x viz/animate_shoreline.py\n
+ 1039  24.10.2025 18:01  cd ~/Desktop/1024CEM/cem/_build/runs/minimal
+ 1040  24.10.2025 18:01  python3 ../../viz/plot_shoreline.py --input "ShorePos_*.dat" --out shoreline_snapshots.png
+ 1041  24.10.2025 18:02  python3 ~/Desktop/1024CEM/cem/viz/plot_shoreline.py --input "ShorePos_*.dat" --out shoreline_snapshots.png
+ 1042  24.10.2025 18:03  python3 ~/Desktop/1024CEM/cem/viz/animate_shoreline.py --input "ShorePos_*.dat" --gif shoreline.gif
+ 1043  24.10.2025 18:10  cd ~/Desktop/1024CEM/cem
+ 1044  24.10.2025 18:10  grep -Rn "ShorePos_" -n .
+ 1045  24.10.2025 18:21  cd ~/Desktop/1024CEM/cem
+ 1046  24.10.2025 18:21  grep -Rn "SAVE_SPACING\|SaveSpacing" cem
+ 1047  24.10.2025 18:36  cd ~/Desktop/1024CEM/cem
+ 1048  24.10.2025 18:36  cmake --build _build -j
+ 1049  24.10.2025 18:36  mkdir -p _build/runs/more
+ 1050  24.10.2025 18:37  cd _build/runs/more
+ 1051  24.10.2025 18:37  ../../cem
+ 1052  24.10.2025 18:37  ls ShorePos_*.dat | wc -l
+ 1053  24.10.2025 18:39  python3 ~/Desktop/1024CEM/cem/viz/plot_shoreline.py \\n  --input "ShorePos_*.dat" \\n  --out shoreline_snapshots.png\nopen shoreline_snapshots.png
+ 1054  24.10.2025 18:39  python3 ~/Desktop/1024CEM/cem/viz/animate_shoreline.py \\n  --input "ShorePos_*.dat" \\n  --gif shoreline_true.gif \\n  --fps 6\nopen shoreline_true.gif
+ 1055  24.10.2025 18:42  python3 - <<'PY'\nimport glob, numpy as np, matplotlib.pyplot as plt, pathlib, re, io\ndef load(path):\n    txt = open(path,'r',encoding='utf-8',errors='ignore').read().replace('%','').strip()\n    arr = np.loadtxt(io.StringIO(re.sub(r'\s+',' ',txt)))\n    return arr if arr.ndim==1 else arr[:,1] if arr.shape[1]>1 else arr[:,0]\n\nfiles = sorted(glob.glob("ShorePos_*.dat"),\n               key=lambda s:int(re.search(r'(\d+)', pathlib.Path(s).stem).group(1)))\nk = 8                                  \nsel_idx = np.linspace(0, len(files)-1, k).astype(int)\nsel = [files[i] for i in sel_idx]\n\nxs = None\nplt.figure(figsize=(9,4))\nfor f in sel:\n    y = load(f)\n    if xs is None: xs = np.arange(len(y))\n    plt.plot(xs, y, alpha=0.7, label=pathlib.Path(f).stem)\nplt.xlabel("Alongshore cell index"); plt.ylabel("Shoreline position y")\nplt.title("CEM Shoreline Snapshots (subset)")\nplt.legend(ncol=2, fontsize=8, framealpha=0.8)\nplt.tight_layout(); plt.savefig("shoreline_subset.png", dpi=220)\nprint("Saved shoreline_subset.png with", len(sel), "curves")\nPY\nopen shoreline_subset.png
+ 1056  24.10.2025 18:43  python3 - <<'PY'\nimport glob, numpy as np, matplotlib.pyplot as plt, re, io, pathlib\ndef load(path):\n    txt=open(path,'r',encoding='utf-8',errors='ignore').read().replace('%','').strip()\n    import re, io; txt=re.sub(r'\s+',' ',txt)\n    a=np.loadtxt(io.StringIO(txt)); return a if a.ndim==1 else a[:,1] if a.shape[1]>1 else a[:,0]\n\nfiles=sorted(glob.glob("ShorePos_*.dat"),\n             key=lambda s:int(re.search(r'(\d+)', pathlib.Path(s).stem).group(1)))\nYs=[load(f) for f in files]\nYs=np.vstack(Ys)\nx=np.arange(Ys.shape[1])\nmu=Ys.mean(axis=0); sd=Ys.std(axis=0)\n\nplt.figure(figsize=(9,4))\nplt.fill_between(x, mu-sd, mu+sd, alpha=0.25, label='mean ± 1σ')\nplt.plot(x, mu, lw=2, label='mean')\nplt.plot(x, Ys[0],  lw=1.2, label=pathlib.Path(files[0]).stem)\nplt.plot(x, Ys[-1], lw=1.2, label=pathlib.Path(files[-1]).stem)\nplt.xlabel("Alongshore cell index"); plt.ylabel("y")\nplt.title("CEM shoreline: mean ± std + first/last")\nplt.legend(framealpha=0.8); plt.tight_layout(); plt.savefig("shoreline_band.png", dpi=220)\nprint("Saved shoreline_band.png")\nPY\nopen shoreline_band.png\n
+ 1057  24.10.2025 18:43  python3 - <<'PY'\nimport glob, numpy as np, matplotlib.pyplot as plt, re, io, pathlib\ndef load(path):\n    txt=open(path,'r',encoding='utf-8',errors='ignore').read().replace('%','').strip()\n    import re, io; txt=re.sub(r'\s+',' ',txt)\n    a=np.loadtxt(io.StringIO(txt)); return a if a.ndim==1 else a[:,1] if a.shape[1]>1 else a[:,0]\nfiles=sorted(glob.glob("ShorePos_*.dat"),\n             key=lambda s:int(re.search(r'(\d+)', pathlib.Path(s).stem).group(1)))\nY=np.vstack([load(f) for f in files])           # shape: [time, space]\nplt.figure(figsize=(8,4))\nim=plt.imshow(Y, aspect='auto', origin='lower', interpolation='nearest')\nplt.colorbar(im, label='Shoreline y')\nplt.ylabel('Snapshot index (time)'); plt.xlabel('Alongshore cell index')\nplt.title('CEM shoreline evolution (heatmap)')\nplt.tight_layout(); plt.savefig('shoreline_heatmap.png', dpi=220)\nprint("Saved shoreline_heatmap.png")\nPY\nopen shoreline_heatmap.png\n
+ 1058  24.10.2025 18:44  python3 - <<'PY'\nimport glob, numpy as np, matplotlib.pyplot as plt, re, io, pathlib\ndef load(p):\n    t=open(p,'r',encoding='utf-8',errors='ignore').read().replace('%','').strip()\n    import re, io; t=re.sub(r'\s+',' ',t)\n    a=np.loadtxt(io.StringIO(t)); return a if a.ndim==1 else a[:,1] if a.shape[1]>1 else a[:,0]\nfiles=sorted(glob.glob("ShorePos_*.dat"),\n             key=lambda s:int(re.search(r'(\d+)', pathlib.Path(s).stem).group(1)))\nY=[load(f) for f in files]\nx=np.arange(len(Y[0]))\nbase=Y[0]\nsel_idx=np.linspace(0,len(Y)-1,6).astype(int)   \nplt.figure(figsize=(9,4))\nfor i in sel_idx:\n    plt.plot(x, Y[i]-base, label=pathlib.Path(files[i]).stem, alpha=0.8)\nplt.axhline(0, ls='--', lw=1)\nplt.xlabel("Alongshore cell index"); plt.ylabel("Δy (vs first)")\nplt.title("CEM shoreline change relative to first snapshot")\nplt.legend(ncol=2, fontsize=8, framealpha=0.8)\nplt.tight_layout(); plt.savefig("shoreline_delta_subset.png", dpi=220)\nprint("Saved shoreline_delta_subset.png")\nPY\nopen shoreline_delta_subset.png
+ 1059  24.10.2025 18:48  python3 ~/Desktop/1024CEM/cem/viz/plot_shoreline.py \\n  --input "ShorePos_*.dat" --outdir . --ds 100 --subset 8 --legend\n
+ 1060  24.10.2025 18:51  python3 ~/Desktop/1024CEM/cem/viz/animate_shoreline_enhanced.py \\n  --input "ShorePos_*.dat" --gif shoreline_true.gif --interval 400
+ 1061  24.10.2025 18:51  python3 ~/Desktop/1024CEM/cem/viz/animate_shoreline_enhanced.py \\n  --input "ShorePos_*.dat" --gif s.gif --mp4 s.mp4 --fps 6 --ylim 0 20
+ 1062  24.10.2025 18:52  python3 ~/Desktop/1024CEM/cem/viz/plot_shoreline_enhanced.py \\n  --input "ShorePos_*.dat" --outdir . --ds 100 --subset 8 --legend\n
+ 1063  24.10.2025 18:54  python3 ~/Desktop/1024CEM/cem/viz/animate_shoreline_enhanced.py \\n  --input "ShorePos_*.dat" --gif shoreline_true.gif --interval 400
+ 1064  24.10.2025 19:07  fc -ln 1 > ~/Desktop/cem_cmds_$(date +%Y%m%d).txt
+ 1065  24.10.2025 19:09  echo 'setopt EXTENDED_HISTORY' >> ~/.zshrc\nsource ~/.zshrc
+ 1066  24.10.2025 19:10  HISTTIMEFORMAT='%Y-%m-%d %H:%M:%S  '  # pretty-print when using history\nbuiltin history -E 1 > ~/Desktop/cem_cmds_$(date +%Y%m%d)_ts.txt
+ 1067  24.10.2025 19:10  HISTTIMEFORMAT='%Y-%m-%d %H:%M:%S  ' history -E 1 \\n| awk -v d="$(date +%Y-%m-%d)" '$0 ~ d' \\n> ~/Desktop/cem_cmds_today_$(date +%Y%m%d).txt
+ 1068  24.10.2025 19:11  echo 'setopt EXTENDED_HISTORY' >> ~/.zshrc\nsource ~/.zshrc
+ 1069  24.10.2025 19:11  HISTTIMEFORMAT='%Y-%m-%d %H:%M:%S  ' history -E 1 \\n| awk -v d="$(date +%Y-%m-%d)" '$0 ~ d' \\n> ~/Desktop/cem_cmds_today_$(date +%Y%m%d).txt
+```

--- a/viz/animate_shoreline.py
+++ b/viz/animate_shoreline.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse, glob, io, re
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, PillowWriter
+from pathlib import Path
+
+def load_shoreline(path):
+    txt = Path(path).read_text(encoding="utf-8", errors="ignore").replace("%","").strip()
+    txt = re.sub(r"\s+", " ", txt)
+    arr = np.loadtxt(io.StringIO(txt))
+    return arr if arr.ndim == 1 else arr[:,1] if arr.shape[1] > 1 else arr[:,0]
+
+def main():
+    p = argparse.ArgumentParser(description="Animate CEM shoreline snapshots.")
+    p.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")
+    p.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m). If not set, x is cell index.")
+    p.add_argument("--gif", default="shoreline.gif", help="Output GIF filename")
+    p.add_argument("--interval", type=int, default=300, help="Frame interval (ms)")
+    args = p.parse_args()
+
+    files = sorted(glob.glob(args.input))
+    if not files:
+        raise SystemExit(f"No files match: {args.input}")
+
+    ys = [load_shoreline(f) for f in files]
+    n = len(ys[0])
+    x = np.arange(n) if args.ds is None else np.arange(n) * args.ds
+
+    ymin = min(map(np.min, ys))
+    ymax = max(map(np.max, ys))
+
+    fig, ax = plt.subplots()
+    (line,) = ax.plot(x, ys[0])
+    ax.set_xlim(x.min(), x.max())
+    ax.set_ylim(ymin, ymax)
+    ax.set_xlabel("Alongshore distance (m)" if args.ds is not None else "Alongshore cell index")
+    ax.set_ylabel("Shoreline position y")
+    title = ax.set_title(Path(files[0]).stem)
+
+    def update(i):
+        line.set_ydata(ys[i])
+        title.set_text(Path(files[i]).stem)
+        return (line, title)
+
+    anim = FuncAnimation(fig, update, frames=len(ys), interval=args.interval, blit=True)
+    anim.save(args.gif, writer=PillowWriter(fps=1000//args.interval))
+    print(f"Saved {args.gif}")
+
+if __name__ == "__main__":
+    main()

--- a/viz/animate_shoreline_enhanced.py
+++ b/viz/animate_shoreline_enhanced.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Animate CEM shoreline snapshots.
+
+Examples (run inside a run folder):
+  # basic GIF, 6 fps
+  python3 ../../viz/animate_shoreline.py --input "ShorePos_*.dat" --gif shoreline.gif --fps 6
+
+  # slower (interval in ms), with 10 in-betweens between each pair
+  python3 ../../viz/animate_shoreline.py --input "ShorePos_*.dat" --gif shoreline_smooth.gif --interval 400 --interp 10
+
+  # export both GIF and MP4, set alongshore spacing to meters, and fix y-limits
+  python3 ../../viz/animate_shoreline.py --input "ShorePos_*.dat" --gif s.gif --mp4 s.mp4 --fps 5 --ds 100 --ylim 0 20
+"""
+
+import argparse, glob, io, re
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, PillowWriter
+
+# --------------------- helpers ---------------------
+
+def _numeric_key(p: Path):
+    m = re.search(r'(\d+)', p.stem)
+    return int(m.group(1)) if m else p.stem
+
+def load_shoreline(path: Path, ycol: int = 1):
+    """Load one shoreline snapshot (robust to stray % and whitespace)."""
+    txt = path.read_text(encoding="utf-8", errors="ignore").replace("%", "").strip()
+    txt = re.sub(r"\s+", " ", txt)
+    arr = np.loadtxt(io.StringIO(txt))
+    if arr.ndim == 1:
+        y = arr
+    else:
+        y = arr[:, ycol] if arr.shape[1] > ycol else arr[:, 0]
+    return np.asarray(y, dtype=float)
+
+def build_frames(base_frames, interp: int):
+    """Insert linear in-betweens between successive 1D arrays."""
+    if interp <= 0:
+        return list(base_frames)
+    out = []
+    for i in range(len(base_frames) - 1):
+        a, b = base_frames[i], base_frames[i + 1]
+        out.append(a)
+        for k in range(1, interp + 1):
+            w = k / (interp + 1.0)
+            out.append((1 - w) * a + w * b)
+    out.append(base_frames[-1])
+    return out
+
+# --------------------- main ---------------------
+
+def main():
+    ap = argparse.ArgumentParser(description="Animate CEM shoreline snapshots.")
+    ap.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")
+    ap.add_argument("--ycol", type=int, default=1, help="y-column if file has multiple columns (0-based)")
+    ap.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m); if None, x is cell index")
+    ap.add_argument("--gif", default="shoreline.gif", help="GIF filename (set to '' to disable)")
+    ap.add_argument("--mp4", default="", help="Optional MP4 filename (requires ffmpeg)")
+    ap.add_argument("--fps", type=int, default=None, help="Frames per second (alternative to --interval)")
+    ap.add_argument("--interval", type=int, default=None, help="Frame interval in ms (alternative to --fps)")
+    ap.add_argument("--interp", type=int, default=0, help="Linear in-between frames per pair (>=0)")
+    ap.add_argument("--figsize", type=float, nargs=2, default=[9, 4], help="Figure size (inches)")
+    ap.add_argument("--ylim", type=float, nargs=2, default=None, help="y-axis limits, e.g. --ylim 0 20")
+    ap.add_argument("--title", default="CEM shoreline animation", help="Figure title")
+    args = ap.parse_args()
+
+    files = sorted([Path(f) for f in glob.glob(args.input)], key=_numeric_key)
+    if not files:
+        raise SystemExit(f"No files match: {args.input}")
+
+    # load base snapshots
+    base = [load_shoreline(f, args.ycol) for f in files]
+    n = base[0].size
+    # x axis
+    x = np.arange(n) if args.ds is None else np.arange(n) * args.ds
+
+    # stack for auto y-limits
+    stack = np.vstack(base)
+    ymin, ymax = stack.min(), stack.max()
+    pad = 0.05 * (ymax - ymin if ymax > ymin else 1.0)
+    if args.ylim is None:
+        ylims = (ymin - pad, ymax + pad)
+    else:
+        ylims = (args.ylim[0], args.ylim[1])
+
+    # interpolate (optional)
+    frames = build_frames(base, max(0, args.interp))
+
+    # fps / interval
+    if args.fps is not None and args.interval is not None:
+        # prefer fps; if both provided, interval will be ignored
+        pass
+    if args.interval is None:
+        fps = args.fps if args.fps is not None else 6
+        interval = int(1000 / max(1, fps))
+    else:
+        interval = max(1, args.interval)
+
+    # figure
+    plt.close("all")
+    fig, ax = plt.subplots(figsize=tuple(args.figsize))
+    (line,) = ax.plot(x, frames[0], lw=1.6)
+    ax.set_xlim(x[0], x[-1])
+    ax.set_ylim(*ylims)
+    ax.set_xlabel("Alongshore distance (m)" if args.ds is not None else "Alongshore cell index")
+    ax.set_ylabel("Shoreline position y")
+    title = ax.set_title(f"{args.title}  |  {files[0].stem}")
+
+    # map each frame to a title (file-based names; interpolated frames show '→')
+    names = []
+    for i in range(len(base) - 1):
+        names.append(files[i].stem)
+        names += [f"{files[i].stem}→{files[i+1].stem}"] * max(0, args.interp)
+    names.append(files[-1].stem)
+
+    def update(i):
+        line.set_ydata(frames[i])
+        title.set_text(f"{args.title}  |  {names[i]}")
+        return (line, title)
+
+    anim = FuncAnimation(fig, update, frames=len(frames), interval=interval, blit=True)
+
+    # export GIF
+    if args.gif:
+        writer = PillowWriter(fps=1000 // interval)
+        anim.save(args.gif, writer=writer, dpi=160)
+        print(f"Saved GIF: {args.gif}  (frames={len(frames)}, fps≈{1000//interval})")
+
+    # optional MP4 (requires ffmpeg in PATH)
+    if args.mp4:
+        try:
+            anim.save(args.mp4, writer="ffmpeg", fps=1000 // interval, dpi=160)
+            print(f"Saved MP4: {args.mp4}")
+        except Exception as e:
+            print(f"[warn] MP4 export failed (need ffmpeg?): {e}")
+
+if __name__ == "__main__":
+    main()

--- a/viz/plot_shoreline.py
+++ b/viz/plot_shoreline.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import argparse, glob, io, re
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+def load_shoreline(path, cols):
+    txt = Path(path).read_text(encoding="utf-8", errors="ignore")
+    txt = txt.replace("%","").strip()
+    txt = re.sub(r"\s+", " ", txt)
+    arr = np.loadtxt(io.StringIO(txt))
+    if arr.ndim == 1:
+        y = arr
+    else:
+        y = arr[:, cols[1]] if arr.shape[1] > 1 else arr[:,0]
+    return y
+
+def main():
+    p = argparse.ArgumentParser(description="Plot CEM shoreline snapshots.")
+    p.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")
+    p.add_argument("--cols", type=int, nargs=2, default=[0,1], help="Zero-based columns for x,y (used if file has multiple columns)")
+    p.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m). If not set, x is cell index.")
+    p.add_argument("--labels", default=None, help="Comma-separated legend labels (same order as sorted files)")
+    p.add_argument("--out", default="shoreline_snapshots.png", help="Output PNG filename")
+    args = p.parse_args()
+
+    files = sorted(glob.glob(args.input))
+    if not files:
+        raise SystemExit(f"No files match: {args.input}")
+
+    labels = args.labels.split(",") if args.labels else None
+    if labels and len(labels) != len(files):
+        raise SystemExit("Number of labels must match number of files.")
+
+    xs = None
+    plt.figure()
+    for i, f in enumerate(files):
+        y = load_shoreline(f, args.cols)
+        if xs is None:
+            n = len(y)
+            xs = np.arange(n) if args.ds is None else np.arange(n) * args.ds
+        lab = labels[i] if labels else Path(f).stem
+        plt.plot(xs, y, label=lab)
+
+    plt.xlabel("Alongshore distance (m)" if args.ds is not None else "Alongshore cell index")
+    plt.ylabel("Shoreline position y")
+    plt.title("CEM Shoreline Snapshots")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(args.out, dpi=220)
+    print(f"Saved {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/viz/plot_shoreline_enhanced.py
+++ b/viz/plot_shoreline_enhanced.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+CEM shoreline visualization toolkit (enhanced)
+
+Generates multiple figures from a set of ShorePos_*.dat snapshots:
+  1) overlay:      all snapshots overlaid (careful when N is large)
+  2) subset:       evenly sampled subset overlaid (cleaner)
+  3) band:         mean ± std band + first & last curves
+  4) heatmap:      time (rows) × alongshore (cols) image
+  5) delta:        change relative to a reference snapshot (default: first)
+
+Usage (from a run folder):
+  python3 ../../viz/plot_shoreline.py --input "ShorePos_*.dat" --outdir . --ds 100 --subset 8
+"""
+
+import argparse, glob, io, re
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+# --------------------------- IO helpers ---------------------------
+
+def _numeric_key(p: Path):
+    """Sort files like ShorePos_2, ShorePos_10 in numeric order."""
+    m = re.search(r'(\d+)', p.stem)
+    return int(m.group(1)) if m else p.stem
+
+def load_shoreline(path: Path, cols):
+    """Load a shoreline snapshot; tolerate single-row and multi-col files."""
+    txt = path.read_text(encoding="utf-8", errors="ignore").replace("%", "").strip()
+    txt = re.sub(r"\s+", " ", txt)
+    arr = np.loadtxt(io.StringIO(txt))
+
+    if arr.ndim == 1:
+        y = arr
+    else:
+        # If multi-column, pick provided y-column (default second col)
+        y = arr[:, cols[1]] if arr.shape[1] > 1 else arr[:, 0]
+    return y
+
+def load_all(files, cols):
+    Ys = []
+    for f in files:
+        y = load_shoreline(f, cols)
+        Ys.append(y)
+    Ys = np.vstack(Ys)  # shape: [time, space]
+    return Ys
+
+# --------------------------- Plot helpers ---------------------------
+
+def _x_axis(npts, ds):
+    x = np.arange(npts)
+    return x if ds is None else x * ds
+
+def _fig(figsize):
+    return plt.figure(figsize=figsize) if figsize else plt.figure()
+
+def _save(fname, dpi):
+    plt.tight_layout()
+    plt.savefig(fname, dpi=dpi)
+    print(f"Saved {fname}")
+
+# --------------------------- Main plotting ---------------------------
+
+def plot_overlay(files, Ys, ds, show_legend, alpha, figsize, dpi, outpath):
+    _fig(figsize)
+    x = _x_axis(Ys.shape[1], ds)
+    for i, f in enumerate(files):
+        plt.plot(x, Ys[i], alpha=alpha, label=f.stem)
+    plt.xlabel("Alongshore distance (m)" if ds is not None else "Alongshore cell index")
+    plt.ylabel("Shoreline position y")
+    plt.title("CEM Shoreline Snapshots (all)")
+    if show_legend:
+        plt.legend(ncol=2, fontsize=8, framealpha=0.85)
+    _save(outpath, dpi)
+
+def plot_subset(files, Ys, ds, k, show_legend, alpha, figsize, dpi, outpath):
+    k = max(1, min(k, len(files)))
+    idx = np.linspace(0, len(files) - 1, k).astype(int)
+    sel_files = [files[i] for i in idx]
+    _fig(figsize)
+    x = _x_axis(Ys.shape[1], ds)
+    for i in idx:
+        plt.plot(x, Ys[i], alpha=alpha, label=files[i].stem)
+    plt.xlabel("Alongshore distance (m)" if ds is not None else "Alongshore cell index")
+    plt.ylabel("Shoreline position y")
+    plt.title(f"CEM Shoreline Snapshots (subset k={k})")
+    if show_legend:
+        plt.legend(ncol=2, fontsize=8, framealpha=0.85)
+    _save(outpath, dpi)
+
+def plot_band(files, Ys, ds, figsize, dpi, outpath):
+    x = _x_axis(Ys.shape[1], ds)
+    mu = Ys.mean(axis=0)
+    sd = Ys.std(axis=0)
+    _fig(figsize)
+    plt.fill_between(x, mu - sd, mu + sd, alpha=0.25, label="mean ± 1σ")
+    plt.plot(x, mu, lw=2, label="mean")
+    plt.plot(x, Ys[0],  lw=1.2, label=files[0].stem)
+    plt.plot(x, Ys[-1], lw=1.2, label=files[-1].stem)
+    plt.xlabel("Alongshore distance (m)" if ds is not None else "Alongshore cell index")
+    plt.ylabel("Shoreline position y")
+    plt.title("CEM shoreline: mean ± std + first/last")
+    plt.legend(framealpha=0.85)
+    _save(outpath, dpi)
+
+def plot_heatmap(Ys, ds, figsize, dpi, outpath):
+    _fig(figsize)
+    im = plt.imshow(Ys, aspect="auto", origin="lower", interpolation="nearest")
+    plt.colorbar(im, label="Shoreline y")
+    plt.ylabel("Snapshot index (time)")
+    plt.xlabel("Alongshore distance (m)" if ds is not None else "Alongshore cell index")
+    plt.title("CEM shoreline evolution (heatmap)")
+    _save(outpath, dpi)
+
+def plot_delta(files, Ys, ds, ref_index, k, show_legend, alpha, figsize, dpi, outpath):
+    ref_index = max(0, min(ref_index, Ys.shape[0]-1))
+    base = Ys[ref_index]
+    x = _x_axis(Ys.shape[1], ds)
+    # choose subset
+    k = max(1, min(k, Ys.shape[0]))
+    idx = np.linspace(0, Ys.shape[0]-1, k).astype(int)
+    _fig(figsize)
+    for i in idx:
+        plt.plot(x, Ys[i] - base, alpha=alpha, label=files[i].stem)
+    plt.axhline(0, ls="--", lw=1)
+    plt.xlabel("Alongshore distance (m)" if ds is not None else "Alongshore cell index")
+    plt.ylabel("Δy (relative to reference)")
+    plt.title(f"CEM shoreline change (ref={files[ref_index].stem})")
+    if show_legend:
+        plt.legend(ncol=2, fontsize=8, framealpha=0.85)
+    _save(outpath, dpi)
+
+# --------------------------- CLI ---------------------------
+
+def main():
+    p = argparse.ArgumentParser(description="Plot CEM shoreline snapshots (multiple figure types).")
+    p.add_argument("--input", default="ShorePos_*.dat", help="Glob for shoreline files")
+    p.add_argument("--cols", type=int, nargs=2, default=[0, 1], help="y-column selection if file has multiple columns")
+    p.add_argument("--ds", type=float, default=None, help="Alongshore spacing (m). If not set, x is cell index.")
+    p.add_argument("--outdir", default=".", help="Directory to write figures")
+    p.add_argument("--dpi", type=int, default=220, help="Figure DPI")
+    p.add_argument("--figsize", type=float, nargs=2, default=[9, 4], help="Figure size (inches), e.g., --figsize 9 4")
+    p.add_argument("--alpha", type=float, default=0.8, help="Line transparency for overlays")
+    p.add_argument("--legend", action="store_true", help="Show legends on overlay/subset/delta")
+    # subset & delta options
+    p.add_argument("--subset", type=int, default=8, help="How many curves to show in subset / delta plots")
+    p.add_argument("--ref-index", type=int, default=0, help="Reference index for Δy plot (0=first, -1=last allowed too)")
+    # toggles
+    p.add_argument("--no-overlay", action="store_true", help="Skip the full overlay figure")
+    p.add_argument("--no-subset", action="store_true", help="Skip the subset overlay figure")
+    p.add_argument("--no-band", action="store_true", help="Skip the mean±std band figure")
+    p.add_argument("--no-heatmap", action="store_true", help="Skip the heatmap figure")
+    p.add_argument("--no-delta", action="store_true", help="Skip the Δy (relative change) figure")
+
+    args = p.parse_args()
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted([Path(f) for f in glob.glob(args.input)], key=_numeric_key)
+    if not files:
+        raise SystemExit(f"No files match: {args.input}")
+
+    Ys = load_all(files, args.cols)  # [time, space]
+    figsize = tuple(args.figsize)
+
+    # 1) full overlay
+    if not args.no_overlay:
+        plot_overlay(files, Ys, args.ds, args.legend, args.alpha, figsize, args.dpi,
+                     outdir / "shoreline_overlay.png")
+
+    # 2) subset overlay
+    if not args.no_subset:
+        plot_subset(files, Ys, args.ds, args.subset, args.legend, args.alpha, figsize, args.dpi,
+                    outdir / "shoreline_subset.png")
+
+    # 3) mean ± std band
+    if not args.no_band:
+        plot_band(files, Ys, args.ds, figsize, args.dpi, outdir / "shoreline_band.png")
+
+    # 4) heatmap
+    if not args.no_heatmap:
+        plot_heatmap(Ys, args.ds, figsize, args.dpi, outdir / "shoreline_heatmap.png")
+
+    # 5) delta vs reference
+    if not args.no_delta:
+        ref = args.ref_index if args.ref_index >= 0 else (Ys.shape[0] + args.ref_index)
+        plot_delta(files, Ys, args.ds, ref, args.subset, args.legend, args.alpha, figsize, args.dpi,
+                   outdir / "shoreline_delta.png")
+
+if __name__ == "__main__":
+    main()

--- a/viz/requirements.txt
+++ b/viz/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+matplotlib
+pillow   # for GIF export


### PR DESCRIPTION
**What & why**
Add small visualization helpers (plots + GIF/MP4) to make it easier to inspect CEM shoreline evolution and share quick QA figures. Also fixes minor macOS build warnings.

**What’s in here**

* Core: add `<stdio.h>` and `<math.h>` includes in `cem/conditions.c` (AppleClang implicit-decl fix).
* Viz (`viz/`):

  * `plot_shoreline.py` — overlay, subset, mean±1σ band, heatmap, Δy.
  * `animate_shoreline.py` — GIF/MP4 (`--fps`/`--interval`, `--interp`, optional `--ylim`).
  * `requirements.txt` — `numpy`, `matplotlib`, `pillow`.
* Hygiene: `.gitignore`.
* Notes: brief run/viz log under `notes/`.

> **Scope note:** This PR does **not** change `SAVE_SPACING`. For demos, I used a higher local save rate only to make animations clearer. If useful, I’m happy to follow up with a runtime flag (e.g., `--save-every N`).

**How to try**

```bash
cd cem
cmake -S . -B _build && cmake --build _build -j
mkdir -p _build/runs/demo && cd _build/runs/demo && ../../cem
python3 ../../viz/plot_shoreline.py --input "ShorePos_*.dat" --outdir . --subset 8 --legend
python3 ../../viz/animate_shoreline.py --input "ShorePos_*.dat" --gif shoreline.gif --fps 5 --interp 10
```

**Thank you**
Open to edits—happy to adjust names, defaults, or placement to fit project style.